### PR TITLE
Don't pipe rm -rvf through sed

### DIFF
--- a/bin/clean
+++ b/bin/clean
@@ -21,7 +21,7 @@ if [[ -f ".slugignore" ]]; then
 
     ls -1d **$line 2>/dev/null |
     while read filepath; do
-      rm -rvf "$filepath"
+      rm -rvf "$filepath" &>/dev/null
     done
 
   done < .slugignore

--- a/bin/clean
+++ b/bin/clean
@@ -21,7 +21,7 @@ if [[ -f ".slugignore" ]]; then
 
     ls -1d **$line 2>/dev/null |
     while read filepath; do
-      rm -rvf "$filepath" | indent
+      rm -rvf "$filepath"
     done
 
   done < .slugignore

--- a/bin/clean
+++ b/bin/clean
@@ -21,7 +21,7 @@ if [[ -f ".slugignore" ]]; then
 
     ls -1d **$line 2>/dev/null |
     while read filepath; do
-      rm -rvf "$filepath" &>/dev/null
+      rm -rf "$filepath" &>/dev/null
     done
 
   done < .slugignore


### PR DESCRIPTION
From @apatzer:

```
Heroku sometimes fails with the message “sed: couldn't flush stdout:

Resource temporarily unavailable” once you start to get into the thousands of files removed range.
```

I've seen seeing this too when removing large cache directories or `node_modules` (when they're only using to compile to bundle js files).

This also removes the verbose flag from `rm` since we're not outputting it anyway.

Fixes #2 